### PR TITLE
Refs #3 Use latest version of our config packages

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -38,6 +38,16 @@ module.exports = class extends Generator {
 
    install() {
       this.npmInstall();
+      this._installLatestVersionOfDependencies();
+   }
+
+   _installLatestVersionOfDependencies() {
+      const LATEST_DEV_DEPS = [
+         '@silvermine/eslint-config@latest',
+         '@silvermine/typescript-config@latest',
+      ];
+
+      this.npmInstall(LATEST_DEV_DEPS, { 'save-dev': true, 'save-exact': true });
    }
 
    _generateProjectConfigFiles() {

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -28,8 +28,6 @@
    },
    "devDependencies": {
       "@silvermine/chai-strictly-equal": "1.0.0",
-      "@silvermine/eslint-config": "2.0.0-rc2",
-      "@silvermine/typescript-config": "0.9.0",
       "@types/chai": "4.1.7",
       "@types/mocha": "5.2.5",
       "@types/node": "8.10.36",


### PR DESCRIPTION
@silvermine/eslint-config and @silvermine/typescript-config both had
hard-coded versions in the generated package.json. Instead of
hard-coding the version, we install the latest version as part of the
`install` lifecycle hook so that we do not need to constantly upgrade
the version on the pacakge.json template.