### PR TITLE
Fixes #12 Split up Gruntfile template and add missing tasks

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -84,7 +84,10 @@ module.exports = class extends Generator {
    }
 
    _generateGruntfile() {
-      this._copyTemplate([ 'Gruntfile.js' ]);
+      let environment = this.answers.isBrowser ? 'browser' : 'node',
+          type = this.answers.isLibrary ? 'lib' : 'project';
+
+      this._copyTemplate([ 'gruntfiles', `Gruntfile-${environment}-${type}.js` ], [ 'Gruntfile.js' ]);
    }
 
    _addTsConfigFiles() {

--- a/generators/app/templates/gruntfiles/Gruntfile-browser-lib.js
+++ b/generators/app/templates/gruntfiles/Gruntfile-browser-lib.js
@@ -1,6 +1,5 @@
 'use strict';
 
-<% if (isBrowser) { _%>
 function getEnvironment(grunt) {
    const TYPES = [ 'prd', 'dev' ],
          env = grunt.option('env');
@@ -8,21 +7,16 @@ function getEnvironment(grunt) {
    return TYPES.indexOf(env) === -1 ? 'dev' : env;
 }
 
-<% } _%>
 module.exports = (grunt) => {
-   <%_ if (isBrowser) { _%>
    const ENVIRONMENT = getEnvironment(grunt);
 
-   <%_ } _%>
    let config;
 
    config = {
       entryFile: './src/index.ts',
       js: {
          gruntFile: 'Gruntfile.js',
-         <%_ if (isBrowser) { _%>
          webpackConfig: 'webpack.config.js',
-         <%_ } _%>
          all: [
             'Gruntfile.js',
             './src/**/*.js',
@@ -37,25 +31,19 @@ module.exports = (grunt) => {
          ],
          configs: {
             standards: 'tsconfig.json',
-            <%_ if (isLibrary) { _%>
             commonjs: 'src/tsconfig.commonjs.json',
             esm: 'src/tsconfig.esm.json',
             types: 'src/tsconfig.types.json',
-            <%_ } _%>
          },
       },
       commands: {
          tsc: './node_modules/.bin/tsc',
-         <%_ if (isBrowser) { %>
          webpack: './node_modules/.bin/webpack',
-         <%_ } _%>
       },
-      <%_ if (isLibrary) { _%>
       out: {
          dist: './dist',
          test: [ './.nyc_output', 'coverage' ],
       },
-      <%_ } _%>
    };
 
    grunt.initConfig({
@@ -73,7 +61,6 @@ module.exports = (grunt) => {
          standards: {
             cmd: `${config.commands.tsc} -p ${config.ts.configs.standards} --pretty`,
          },
-         <%_ if (isLibrary) { _%>
          types: {
             cmd: `${config.commands.tsc} -p ${config.ts.configs.types} --pretty`,
          },
@@ -83,34 +70,21 @@ module.exports = (grunt) => {
          commonjs: {
             cmd: `${config.commands.tsc} -p ${config.ts.configs.commonjs} --pretty`,
          },
-         <%_ } else if (isBrowser) { _%>
-         esm: {
-            cmd: `${config.commands.tsc} -p ${config.ts.configs.esm} --pretty`,
-         },
-         <%_ } _%>
-         <%_ if (isBrowser) { _%>
          webpackUMD: {
             cmd: `${config.commands.webpack} ${config.entryFile} ${ENVIRONMENT === 'prd' ? '--env.production' : ''}`,
          },
-         <%_ } _%>
       },
-      <%_ if (isLibrary) { %>
+
       clean: {
          dist: config.out.dist,
          testOutput: config.out.test,
       },
-      <%_ } _%>
-      <%_ if (isLibrary) { %>
+
       concurrent: {
          'build-ts-outputs': [ 'build-types', 'build-esm', 'build-commonjs' ],
-         <%_ if (isBrowser) { _%>
          'build': [ 'build-ts-outputs', 'build-umd' ],
-         <%_ } _%>
       },
-      <%_ } _%>
-      <%_ if (isLibrary) { %>
       watch: {
-         <%_ if (isBrowser) { _%>
          ts: {
             files: [ config.ts.src ],
             tasks: [ 'build' ],
@@ -119,12 +93,6 @@ module.exports = (grunt) => {
             files: [ config.js.webpackConfig ],
             tasks: [ 'build-umd' ],
          },
-         <%_ } else { _%>
-         ts: {
-            files: [ config.ts.src ],
-            tasks: [ 'build-ts-outputs' ],
-         },
-         <%_ } _%>
          gruntFile: {
             files: [ config.js.gruntFile ],
             options: {
@@ -132,37 +100,23 @@ module.exports = (grunt) => {
             },
          },
       },
-      <%_ } %>
    });
 
    grunt.loadNpmTasks('grunt-eslint');
    grunt.loadNpmTasks('grunt-exec');
-   <%_ if (isLibrary) { _%>
    grunt.loadNpmTasks('grunt-contrib-clean');
    grunt.loadNpmTasks('grunt-concurrent');
    grunt.loadNpmTasks('grunt-contrib-watch');
-   <%_ } _%>
 
    grunt.registerTask('standards', [ 'eslint', 'exec:standards' ]);
    grunt.registerTask('default', [ 'standards' ]);
-   <%_ if (isLibrary) { _%>
 
    grunt.registerTask('build-types', 'exec:types');
    grunt.registerTask('build-esm', 'exec:esm');
    grunt.registerTask('build-commonjs', 'exec:commonjs');
    grunt.registerTask('build-ts-outputs', 'concurrent:build-ts-outputs');
-   <%_ } _%>
-   <%_ if (isBrowser) { %>
    grunt.registerTask('build-umd', 'exec:webpackUMD');
-   <%_ } _%>
-   <%_ if (isLibrary && isBrowser) { %>
    grunt.registerTask('build', [ 'concurrent:build' ]);
-   <%_ } else if (isLibrary) { _%>
-   grunt.registerTask('build', [ 'concurrent:build-ts-outputs' ]);
-   <%_ } else if (isBrowser) { _%>
-   grunt.registerTask('build', [ 'build-umd' ]);
-   <%_ } _%>
-   <%_ if (isLibrary || isBrowser) { %>
-   grunt.registerTask('develop', [ 'clean', 'build', 'watch' ]);
-   <%_ } %>
+
+   grunt.registerTask('develop', [ 'clean:dist', 'build', 'watch' ]);
 };

--- a/generators/app/templates/gruntfiles/Gruntfile-browser-project.js
+++ b/generators/app/templates/gruntfiles/Gruntfile-browser-project.js
@@ -1,0 +1,106 @@
+'use strict';
+
+function getEnvironment(grunt) {
+   const TYPES = [ 'prd', 'dev' ],
+         env = grunt.option('env');
+
+   return TYPES.indexOf(env) === -1 ? 'dev' : env;
+}
+
+module.exports = (grunt) => {
+   const ENVIRONMENT = getEnvironment(grunt);
+
+   let config;
+
+   config = {
+      entryFile: './src/index.ts',
+      js: {
+         gruntFile: 'Gruntfile.js',
+         webpackConfig: 'webpack.config.js',
+         all: [
+            'Gruntfile.js',
+            './src/**/*.js',
+            './tests/**/*.js',
+         ],
+      },
+      ts: {
+         src: './src/**/*.ts',
+         all: [
+            './src/**/*.ts',
+            './tests/**/*.ts',
+         ],
+         configs: {
+            standards: 'tsconfig.json',
+            esm: 'src/tsconfig.esm.json',
+         },
+      },
+      commands: {
+         tsc: './node_modules/.bin/tsc',
+         webpack: './node_modules/.bin/webpack',
+      },
+      out: {
+         dist: './dist',
+         test: [ './.nyc_output', 'coverage' ],
+      },
+   };
+
+   grunt.initConfig({
+
+      pkg: grunt.file.readJSON('package.json'),
+
+      eslint: {
+         target: [ ...config.js.all, ...config.ts.all ],
+      },
+
+      exec: {
+         options: {
+            failOnError: true,
+         },
+         standards: {
+            cmd: `${config.commands.tsc} -p ${config.ts.configs.standards} --pretty`,
+         },
+         esm: {
+            cmd: `${config.commands.tsc} -p ${config.ts.configs.esm} --pretty`,
+         },
+         webpackUMD: {
+            cmd: `${config.commands.webpack} ${config.entryFile} ${ENVIRONMENT === 'prd' ? '--env.production' : ''}`,
+         },
+      },
+
+      clean: {
+         dist: config.out.dist,
+         testOutput: config.out.test,
+      },
+
+      watch: {
+         ts: {
+            files: [ config.ts.src ],
+            tasks: [ 'build' ],
+         },
+         webpackConfig: {
+            files: [ config.js.webpackConfig ],
+            tasks: [ 'build-umd' ],
+         },
+         gruntFile: {
+            files: [ config.js.gruntFile ],
+            options: {
+               reload: true,
+            },
+         },
+      },
+   });
+
+   grunt.loadNpmTasks('grunt-eslint');
+   grunt.loadNpmTasks('grunt-exec');
+   grunt.loadNpmTasks('grunt-contrib-clean');
+   grunt.loadNpmTasks('grunt-contrib-watch');
+
+   grunt.registerTask('standards', [ 'eslint', 'exec:standards' ]);
+   grunt.registerTask('default', [ 'standards' ]);
+
+   grunt.registerTask('build-umd', 'exec:webpackUMD');
+
+   grunt.registerTask('build', [ 'build-umd' ]);
+
+   grunt.registerTask('develop', [ 'clean:dist', 'build', 'watch' ]);
+};

--- a/generators/app/templates/gruntfiles/Gruntfile-node-lib.js
+++ b/generators/app/templates/gruntfiles/Gruntfile-node-lib.js
@@ -1,0 +1,104 @@
+'use strict';
+
+module.exports = (grunt) => {
+   let config;
+
+   config = {
+      entryFile: './src/index.ts',
+      js: {
+         gruntFile: 'Gruntfile.js',
+         all: [
+            'Gruntfile.js',
+            './src/**/*.js',
+            './tests/**/*.js',
+         ],
+      },
+      ts: {
+         src: './src/**/*.ts',
+         all: [
+            './src/**/*.ts',
+            './tests/**/*.ts',
+         ],
+         configs: {
+            standards: 'tsconfig.json',
+            commonjs: 'src/tsconfig.commonjs.json',
+            esm: 'src/tsconfig.esm.json',
+            types: 'src/tsconfig.types.json',
+         },
+      },
+      commands: {
+         tsc: './node_modules/.bin/tsc',
+      },
+      out: {
+         dist: './dist',
+         test: [ './.nyc_output', 'coverage' ],
+      },
+   };
+
+   grunt.initConfig({
+
+      pkg: grunt.file.readJSON('package.json'),
+
+      eslint: {
+         target: [ ...config.js.all, ...config.ts.all ],
+      },
+
+      exec: {
+         options: {
+            failOnError: true,
+         },
+         standards: {
+            cmd: `${config.commands.tsc} -p ${config.ts.configs.standards} --pretty`,
+         },
+         types: {
+            cmd: `${config.commands.tsc} -p ${config.ts.configs.types} --pretty`,
+         },
+         esm: {
+            cmd: `${config.commands.tsc} -p ${config.ts.configs.esm} --pretty`,
+         },
+         commonjs: {
+            cmd: `${config.commands.tsc} -p ${config.ts.configs.commonjs} --pretty`,
+         },
+      },
+
+      clean: {
+         dist: config.out.dist,
+         testOutput: config.out.test,
+      },
+
+      concurrent: {
+         'build-ts-outputs': [ 'build-types', 'build-esm', 'build-commonjs' ],
+      },
+
+      watch: {
+         ts: {
+            files: [ config.ts.src ],
+            tasks: [ 'build-ts-outputs' ],
+         },
+         gruntFile: {
+            files: [ config.js.gruntFile ],
+            options: {
+               reload: true,
+            },
+         },
+      },
+   });
+
+   grunt.loadNpmTasks('grunt-eslint');
+   grunt.loadNpmTasks('grunt-exec');
+   grunt.loadNpmTasks('grunt-contrib-clean');
+   grunt.loadNpmTasks('grunt-concurrent');
+   grunt.loadNpmTasks('grunt-contrib-watch');
+
+   grunt.registerTask('standards', [ 'eslint', 'exec:standards' ]);
+   grunt.registerTask('default', [ 'standards' ]);
+
+   grunt.registerTask('build-types', 'exec:types');
+   grunt.registerTask('build-esm', 'exec:esm');
+   grunt.registerTask('build-commonjs', 'exec:commonjs');
+   grunt.registerTask('build-ts-outputs', 'concurrent:build-ts-outputs');
+
+   grunt.registerTask('build', [ 'concurrent:build-ts-outputs' ]);
+
+   grunt.registerTask('develop', [ 'clean:dist', 'build', 'watch' ]);
+};

--- a/generators/app/templates/gruntfiles/Gruntfile-node-project.js
+++ b/generators/app/templates/gruntfiles/Gruntfile-node-project.js
@@ -1,0 +1,78 @@
+'use strict';
+
+module.exports = (grunt) => {
+   let config;
+
+   config = {
+      entryFile: './src/index.ts',
+      js: {
+         gruntFile: 'Gruntfile.js',
+         all: [
+            'Gruntfile.js',
+            './src/**/*.js',
+            './tests/**/*.js',
+         ],
+      },
+      ts: {
+         src: './src/**/*.ts',
+         all: [
+            './src/**/*.ts',
+            './tests/**/*.ts',
+         ],
+         configs: {
+            standards: 'tsconfig.json',
+         },
+      },
+      commands: {
+         tsc: './node_modules/.bin/tsc',
+      },
+      out: {
+         test: [ './.nyc_output', 'coverage' ],
+      },
+   };
+
+   grunt.initConfig({
+
+      pkg: grunt.file.readJSON('package.json'),
+
+      eslint: {
+         target: [ ...config.js.all, ...config.ts.all ],
+      },
+
+      exec: {
+         options: {
+            failOnError: true,
+         },
+         standards: {
+            cmd: `${config.commands.tsc} -p ${config.ts.configs.standards} --pretty`,
+         },
+      },
+
+      clean: {
+         testOutput: config.out.test,
+      },
+
+      watch: {
+         ts: {
+            files: [ config.ts.src ],
+            tasks: [ 'standards' ],
+         },
+         gruntFile: {
+            files: [ config.js.gruntFile ],
+            options: {
+               reload: true,
+            },
+         },
+      },
+   });
+
+   grunt.loadNpmTasks('grunt-eslint');
+   grunt.loadNpmTasks('grunt-exec');
+   grunt.loadNpmTasks('grunt-contrib-clean');
+   grunt.loadNpmTasks('grunt-contrib-watch');
+
+   grunt.registerTask('standards', [ 'eslint', 'exec:standards' ]);
+   grunt.registerTask('default', [ 'standards' ]);
+
+   grunt.registerTask('develop', [ 'watch' ]);
+};

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -37,9 +37,9 @@
       "grunt-cli": "1.3.1",
       <%_ if (isLibrary) { _%>
       "grunt-concurrent": "2.3.1",
+      <%_ } _%>
       "grunt-contrib-clean": "2.0.0",
       "grunt-contrib-watch": "1.1.0",
-      <%_ } _%>
       "grunt-eslint": "21.0.0",
       "grunt-exec": "3.0.0",
       <%_ if (isBrowser) { _%>


### PR DESCRIPTION
Split the Gruntfile.js template up into multiple files, one for each
kind of output, so that it's easier to read and maintain. The Gruntfile
had too many `if` statements / branches to be maintainable and easily
understood.

This new organization more easily revealed that some of the outputted
Gruntfiles had missing tasks (`clean` and `watch` for certain outputs).
These missing tasks were added.