### PR TITLE
Fixes #16 Whitelist files to run TypeScript standards task against

### DIFF
--- a/generators/app/templates/tsconfig.json
+++ b/generators/app/templates/tsconfig.json
@@ -1,7 +1,11 @@
 {
    <%_ if (isBrowser) { _%>
-   "extends": "@silvermine/typescript-config/browser/tsconfig.json"
+   "extends": "@silvermine/typescript-config/browser/tsconfig.json",
    <%_ } else { _%>
-   "extends": "@silvermine/typescript-config/tsconfig.json"
+   "extends": "@silvermine/typescript-config/tsconfig.json",
    <%_ } _%>
+   "include": [
+      "src/**/*",
+      "test/**/*"
+   ]
 }


### PR DESCRIPTION
If a tsconfig.json file does not have a `files`, `includes`, or
`excludes` property set, then `tsc` will run against all files / folders
in the same directory as the tsconfig.json file. Because of this, in
generated projects, files in the `dist` folder were getting included in
our standards task. So, we whitelist the folders to run `tsc` against
using the `includes` property.