### PR TITLE
Fixes #19 Make tslib a prd dependency for libraries

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -50,8 +50,10 @@
       "nyc": "13.1.0",
       "sinon": "5.1.1",
       "source-map-support": "0.5.9",
-      "ts-node": "7.0.1",
+<%_ if (!isLibrary) { _%>
       "tslib": "1.9.3",
+<%_ } _%>
+      "ts-node": "7.0.1",
       <%_ if (isBrowser) { _%>
       "ts-loader": "5.3.0",
       <%_ } _%>
@@ -60,5 +62,9 @@
       "webpack-cli": "3.2.0"
       <%_ } _%>
    },
-   "dependencies": {}
+   "dependencies": {
+<%_ if (isLibrary) { _%>
+      "tslib": "1.9.3"
+<%_ } _%>
+   }
  }


### PR DESCRIPTION
Library projects's `esm` and `commonjs` outputs are meant to be consumed
by other projects. When the TypeScript compiler builds these outputs, it
adds statements to import `tslib` into its outputted files when the
TypeScript compiler's [`importHelpers` setting is `true`][1]. This means
that when the user of the library imports the library's code, the
library's code attempts to import `tslib` and an error is thrown if
`tslib` is not found (because it's a dev dependency and not a production
dependency). Thus, we make `tslib` a production dependency for generated
libraries.

[1]: https://www.typescriptlang.org/docs/handbook/compiler-options.html