### PR TITLE
Link NPM version badge to NPM package info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Silvermine TypeScript Project Yeoman Generator
 
-[![NPM Version](https://img.shields.io/npm/v/@silvermine/generator-typescript.svg)](https://travis-ci.com/silvermine/generator-typescript)
+[![NPM Version](https://img.shields.io/npm/v/@silvermine/generator-typescript.svg)](https://www.npmjs.com/package/@silvermine/generator-typescript)
 [![License](https://img.shields.io/github/license/silvermine/generator-typescript.svg)](./LICENSE)
 [![Build Status](https://travis-ci.com/silvermine/generator-typescript.svg?branch=master)](https://travis-ci.com/silvermine/generator-typescript)
 [![Dependency Status](https://david-dm.org/silvermine/generator-typescript.svg)](https://david-dm.org/silvermine/generator-typescript)

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -1,7 +1,7 @@
 # <%= projectName %>
 
 <%_ if (isOpenSource) { _%>
-[![NPM Version](https://img.shields.io/npm/v/@silvermine/<%= projectName %>.svg)](https://travis-ci.com/silvermine/<%= projectName %>)
+[![NPM Version](https://img.shields.io/npm/v/@silvermine/<%= projectName %>.svg)](https://www.npmjs.com/package/@silvermine/<%= projectName %>)
 [![License](https://img.shields.io/github/license/silvermine/<%= projectName %>.svg)](./LICENSE)
 [![Build Status](https://travis-ci.com/silvermine/<%= projectName %>.svg?branch=master)](https://travis-ci.com/silvermine/<%= projectName %>)
 [![Coverage Status](https://coveralls.io/repos/github/silvermine/<%= projectName %>/badge.svg?branch=master)](https://coveralls.io/github/silvermine/<%= projectName %>?branch=master)


### PR DESCRIPTION
While a passing build is good, linking to the NPM package info seems a tad more useful 😉