### PR TITLE
Change default starting version to 0.1.0 (instead of 0.9.0)

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -1,6 +1,6 @@
 {
    "name": "<%_ if (isOpenSource) { _%>@silvermine/<%_ } _%><%= projectName %>",
-   "version": "0.9.0",
+   "version": "0.1.0",
    "description": "",
    <%_ if (isLibrary) { _%>
    "main": "./dist/commonjs/index",


### PR DESCRIPTION
I'm not really sure why we used to start all our projects off as 0.9.0,
but it makes more sense to me to start them off lower. If the first
release of a project is "nearly 1.0" worthy, we can do `npm version
0.9.0` as part of that release. But this gives us more runway to start
off projects that are in real alpha states.