### PR TITLE
Remove --bail from mocha options

### DIFF
--- a/generators/app/templates/_mocha.opts
+++ b/generators/app/templates/_mocha.opts
@@ -1,5 +1,4 @@
 --require source-map-support/register
 --require ./tests/setup/before.ts
 --full-trace
---bail
 tests/**/*.test.ts


### PR DESCRIPTION
The --bail flag makes mocha stop after the first test failure. ADIRL, we didn't
have a specific reason to add this flag. It likely originated from an example
somewhere. As such, removing it so all the failing tests will be reported, not
just the first.