### PR TITLE
fix: upgrade nyc dependency

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -48,7 +48,7 @@
       "jsdom-global": "3.0.2",
       <%_ } _%>
       "mocha": "5.2.0",
-      "nyc": "13.1.0",
+      "nyc": "13.3.0",
       "sinon": "5.1.1",
       "source-map-support": "0.5.9",
 <%_ if (!isLibrary) { _%>


### PR DESCRIPTION
`npm audit` was reporting a high severity vulnerability with the
previous version of `nyc`.