### PR TITLE
fix: Add --forbid-only flag to mocha command when run in CI (#40)

### DIFF
--- a/generators/app/templates/_travis.yml
+++ b/generators/app/templates/_travis.yml
@@ -16,7 +16,7 @@ script:
 <%_ if (isLibrary || isBrowser) { _%>
    - grunt clean build
 <%_ } _%>
-   - npm test
+   - npm run test:ci
 
 # For code coverage:
 after_success:

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -11,7 +11,8 @@
       <%_ if (isLibrary || isBrowser) { _%>
       "prepare": "grunt build",
       <%_ } _%>
-      "test": "TS_NODE_PROJECT='tests/tsconfig.json' TS_NODE_FILES=true nyc mocha --opts ./.mocha.opts"
+      "test": "TS_NODE_PROJECT='tests/tsconfig.json' TS_NODE_FILES=true nyc mocha --opts ./.mocha.opts",
+      "test:ci": "npm test -- --forbid-only"
    },
    "author": "<%= author %>",
    "license": "<%= isOpenSource ? 'MIT' : 'PROPRIETARY' %>",

--- a/tests/scripts/integration-test.sh
+++ b/tests/scripts/integration-test.sh
@@ -27,6 +27,7 @@ cd node-lib
 grunt standards
 grunt clean build
 npm test
+npm run test:ci
 cd ../
 
 # Node.js Non-Library Project
@@ -39,6 +40,7 @@ cd node-project
 ../../node_modules/.bin/yo @silvermine/typescript --projectName=nodeProject --isBackEnd=true --isLibrary=false --isOpenSource=false --force-install
 grunt standards
 npm test
+npm run test:ci
 cd ../
 
 # Front-End Library
@@ -52,6 +54,7 @@ cd front-end-library
 grunt standards
 grunt clean build
 npm test
+npm run test:ci
 cd ../
 
 # Front-End Non-Library Project
@@ -65,3 +68,4 @@ cd front-end-project
 grunt standards
 grunt clean build
 npm test
+npm run test:ci


### PR DESCRIPTION
We can prevent accidentally merging a commit that uses mocha's `.only`
method to only run a single test or a single `describe` block by passing
the --forbid-only flag when running in a CI environment.